### PR TITLE
Fix wordpress directory location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+.vagrant
 .ey_local_data
-
-WordPress/
+latest.tar.gz
+wordpress/

--- a/puppet/modules/wordpress/manifests/init.pp
+++ b/puppet/modules/wordpress/manifests/init.pp
@@ -43,7 +43,7 @@ class wordpress::install{
   
   # Copy a working wp-config.php file for the vagrant setup.
   file{
-    "/vagrant/WordPress/wp-config.php":
+    "/vagrant/wordpress/wp-config.php":
     source=>"puppet:///modules/wordpress/wp-config.php"
   }
   


### PR DESCRIPTION
- puppet module for wordpress had 'WordPress' rather than the existing
  lowercase directory.
- Update .gitignore to include .vagrant and latest tarball

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
