### PR TITLE
Issue #2 fix

### DIFF
--- a/files/etc/apache2/httpd.conf
+++ b/files/etc/apache2/httpd.conf
@@ -1,0 +1,2 @@
+User vagrant
+Group vagrant

--- a/puppet/modules/apache2/manifests/init.pp
+++ b/puppet/modules/apache2/manifests/init.pp
@@ -1,10 +1,22 @@
 class apache2::install{
-  
+
   package { "apache2": ensure => present,}
 
   service { "apache2":
     ensure => running,
     require => Package["apache2"],
+  }
+
+  /*
+    the httpd.conf change the user/group that apache uses to run its process
+   */
+  file { '/etc/apache2/httpd.conf':
+    owner => root,
+    group => root,
+    ensure => file,
+    mode => 644,
+    source => '/vagrant/files/etc/apache2/httpd.conf',
+    require => Package["apache2"]
   }
 
   file { '/etc/apache2/sites-available/default':
@@ -39,5 +51,5 @@ class apache2::install{
     target => "/etc/apache2/mods-available/rewrite.load",
     require => Package["apache2"],
   }
-  
+
 }


### PR DESCRIPTION
I've added a **httpd.conf** file that overrides the _user|group_ that is used to run **apache2**.

Installing a plugin now works immediately after running _vagrant up_
