### PR TITLE
Made sure apache is restarted when user is changed to Vagrant

### DIFF
--- a/puppet/modules/apache2/manifests/init.pp
+++ b/puppet/modules/apache2/manifests/init.pp
@@ -10,13 +10,14 @@ class apache2::install{
   /*
     the httpd.conf change the user/group that apache uses to run its process
    */
-  file { '/etc/apache2/httpd.conf':
+  file { '/etc/apache2/conf.d/user':
     owner => root,
     group => root,
     ensure => file,
     mode => 644,
     source => '/vagrant/files/etc/apache2/httpd.conf',
-    require => Package["apache2"]
+    require => Package["apache2"],
+    notify  => Service['apache2']
   }
 
   file { '/etc/apache2/sites-available/default':
@@ -26,6 +27,7 @@ class apache2::install{
     mode => 644,
     source => '/vagrant/files/etc/apache2/sites-available/default',
     require => Package["apache2"],
+    notify  => Service['apache2']
   }
 
   file { '/etc/apache2/mods-available/rewrite.load':
@@ -35,6 +37,7 @@ class apache2::install{
     mode => 644,
     source => '/vagrant/files/etc/apache2/mods-available/rewrite.load',
     require => Package['apache2'],
+    notify  => Service['apache2']
   }
 
 


### PR DESCRIPTION
Copying the Apache config to httpd.conf didn't result in that user & group being used by the apache process.

This PR copies the user config to conf.d/user & notifies the Apache service to restart to make sure those changes are picked up.

It also means that plugins will install out of the box.
