### PR TITLE
Align puppet manifests with recommended style guide

### DIFF
--- a/puppet/manifests/init.pp
+++ b/puppet/manifests/init.pp
@@ -1,10 +1,10 @@
-exec { "apt_update":
-  command => "apt-get update",
-  path    => "/usr/bin"
+exec { 'apt_update':
+  command => 'apt-get update',
+  path    => '/usr/bin'
 }
 
-  class{'git::install':}
-  class{'apache2::install':}
-  class{'php5::install':}  
-  class{'mysql::install':}
-  class{'wordpress::install':}
+class { 'git::install': }
+class { 'apache2::install': }
+class { 'php5::install': }
+class { 'mysql::install': }
+class { 'wordpress::install': }

--- a/puppet/modules/apache2/manifests/init.pp
+++ b/puppet/modules/apache2/manifests/init.pp
@@ -1,58 +1,59 @@
-class apache2::install{
+# Install Apache
 
-  package { "apache2": ensure => present,}
+class apache2::install {
 
-  service { "apache2":
-    ensure => running,
-    require => Package["apache2"],
+  package { 'apache2':
+    ensure => present,
   }
 
-  /*
-    the httpd.conf change the user/group that apache uses to run its process
-   */
+  service { 'apache2':
+    ensure  => running,
+    require => Package['apache2'],
+  }
+
+  # the httpd.conf change the user/group that apache uses to run its process
   file { '/etc/apache2/conf.d/user':
-    owner => root,
-    group => root,
-    ensure => file,
-    mode => 644,
-    source => '/vagrant/files/etc/apache2/httpd.conf',
-    require => Package["apache2"],
-    notify  => Service['apache2']
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    source  => '/vagrant/files/etc/apache2/httpd.conf',
+    require => Package['apache2'],
+    notify  => Service['apache2'],
   }
 
   file { '/etc/apache2/sites-available/default':
-    owner => root,
-    group => root,
-    ensure => file,
-    mode => 644,
-    source => '/vagrant/files/etc/apache2/sites-available/default',
-    require => Package["apache2"],
-    notify  => Service['apache2']
-  }
-
-  file { '/etc/apache2/mods-available/rewrite.load':
-    owner => root,
-    group => root,
-    ensure => file,
-    mode => 644,
-    source => '/vagrant/files/etc/apache2/mods-available/rewrite.load',
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    source  => '/vagrant/files/etc/apache2/sites-available/default',
     require => Package['apache2'],
     notify  => Service['apache2']
   }
 
+  file { '/etc/apache2/mods-available/rewrite.load':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    source  => '/vagrant/files/etc/apache2/mods-available/rewrite.load',
+    require => Package['apache2'],
+    notify  => Service['apache2']
+  }
 
   file { '/etc/apache2/sites-enabled/000-default':
-    notify => Service["apache2"],
-    ensure => link,
-    target => "/etc/apache2/sites-available/default",
-    require => Package["apache2"],
+    ensure  => link,
+    target  => '/etc/apache2/sites-available/default',
+    require => Package['apache2'],
+    notify  => Service['apache2'],
   }
 
   file { '/etc/apache2/mods-enabled/rewrite.load':
-    notify => Service["apache2"],
-    ensure => link,
-    target => "/etc/apache2/mods-available/rewrite.load",
-    require => Package["apache2"],
+    ensure  => link,
+    target  => '/etc/apache2/mods-available/rewrite.load',
+    require => Package['apache2'],
+    notify  => Service['apache2'],
   }
 
 }

--- a/puppet/modules/git/manifests/init.pp
+++ b/puppet/modules/git/manifests/init.pp
@@ -1,3 +1,9 @@
-class git::install{
-  package{"git": ensure=>present,}
+# Install git
+
+class git::install {
+
+  package{'git':
+    ensure=>present,
+  }
+
 }

--- a/puppet/modules/mysql/manifests/init.pp
+++ b/puppet/modules/mysql/manifests/init.pp
@@ -1,13 +1,25 @@
-class mysql::install {
-  $password = "vagrant"
-  package { "mysql-client": ensure => installed }
-  package { "mysql-server": ensure => installed }
+#Install MySQL
 
-  exec { "Set MySQL server root password":
-    subscribe => [ Package["mysql-server"], Package["mysql-client"] ],
-    refreshonly => true,
-    unless => "mysqladmin -uroot -p$password status",
-    path => "/bin:/usr/bin",
-    command => "mysqladmin -uroot password $password",
+class mysql::install {
+
+  $password = 'vagrant'
+
+  package { [
+      'mysql-client',
+      'mysql-server',
+    ]:
+    ensure => installed,
   }
+
+  exec { 'Set MySQL server\'s root password':
+    subscribe   => [
+      Package['mysql-server'],
+      Package['mysql-client'],
+    ],
+    refreshonly => true,
+    unless      => "mysqladmin -uroot -p${password} status",
+    path        => '/bin:/usr/bin',
+    command     => "mysqladmin -uroot password ${password}",
+  }
+
 }

--- a/puppet/modules/php5/manifests/init.pp
+++ b/puppet/modules/php5/manifests/init.pp
@@ -1,8 +1,16 @@
-class php5::install{
-  package{"php5": ensure=>present,}
-  package{"php5-mysql": ensure=>present,}
-  package{"php5-curl": ensure=>present,}
-  package{"php5-gd": ensure=>present,}
-  package{"php5-fpm": ensure=>present,}
-  package{"libapache2-mod-php5": ensure=>present,}
+# Install PHP
+
+class php5::install {
+
+  package { [
+      'php5',
+      'php5-mysql',
+      'php5-curl',
+      'php5-gd',
+      'php5-fpm',
+      'libapache2-mod-php5',
+    ]:
+    ensure => present,
+  }
+
 }

--- a/puppet/modules/wordpress/manifests/init.pp
+++ b/puppet/modules/wordpress/manifests/init.pp
@@ -1,50 +1,45 @@
-class wordpress::install{
-  
+# Install latest Wordpress
+
+class wordpress::install {
+
   # Create the Wordpress database
-  exec{"create-database":
-    unless=>"/usr/bin/mysql -u root -pvagrant wordpress",
-    command=>"/usr/bin/mysql -u root -pvagrant --execute=\"create database wordpress\"",
+  exec { 'create-database':
+    unless  => '/usr/bin/mysql -u root -pvagrant wordpress',
+    command => '/usr/bin/mysql -u root -pvagrant --execute=\'create database wordpress\'',
   }
-  
-  # Create a MySQL user for wordpress.
-  exec{"create-user":
-    unless=>"/usr/bin/mysql -u wordpress -pwordpress",
-    command=>"/usr/bin/mysql -u root -pvagrant --execute=\"GRANT ALL PRIVILEGES ON wordpress.* TO 'wordpress'@'localhost' IDENTIFIED BY 'wordpress' \"",
+
+  exec { 'create-user':
+    unless  => '/usr/bin/mysql -u wordpress -pwordpress',
+    command => '/usr/bin/mysql -u root -pvagrant --execute="GRANT ALL PRIVILEGES ON wordpress.* TO \'wordpress\'@\'localhost\' IDENTIFIED BY \'wordpress\'"',
   }
-  
+
   # Get a new copy of the latest wordpress release
+  # FILE TO DOWNLOAD: http://wordpress.org/latest.tar.gz
 
-	# FILE TO DOWNLOAD: http://wordpress.org/latest.tar.gz
-
-
-  
-  exec{"git-wordpress": #tee hee
-    command=>"/usr/bin/wget http://wordpress.org/latest.tar.gz",
-    cwd=>"/vagrant/",
-    creates=>"/vagrant/latest.tar.gz"
+  exec { 'download-wordpress': #tee hee
+    command => '/usr/bin/wget http://wordpress.org/latest.tar.gz',
+    cwd     => '/vagrant/',
+    creates => '/vagrant/latest.tar.gz'
   }
 
-  exec{"untar-wordpress":
-    cwd     => "/vagrant/",
-    command => "/bin/tar xzvf /vagrant/latest.tar.gz",
-    require => Exec["git-wordpress"],
+  exec { 'untar-wordpress':
+    cwd     => '/vagrant/',
+    command => '/bin/tar xzvf /vagrant/latest.tar.gz',
+    require => Exec['download-wordpress'],
   }
-  
 
   # Import a MySQL database for a basic wordpress site.
-  file{
-    "/tmp/wordpress-db.sql":
-    source=>"puppet:///modules/wordpress/wordpress-db.sql"
+  file { '/tmp/wordpress-db.sql':
+    source => 'puppet:///modules/wordpress/wordpress-db.sql'
   }
-  
-  exec{"load-db":
-    command=>"/usr/bin/mysql -u wordpress -pwordpress wordpress < /tmp/wordpress-db.sql"
+
+  exec { 'load-db':
+    command => '/usr/bin/mysql -u wordpress -pwordpress wordpress < /tmp/wordpress-db.sql'
   }
-  
+
   # Copy a working wp-config.php file for the vagrant setup.
-  file{
-    "/vagrant/wordpress/wp-config.php":
-    source=>"puppet:///modules/wordpress/wp-config.php"
+  file { '/vagrant/wordpress/wp-config.php':
+    source => 'puppet:///modules/wordpress/wp-config.php'
   }
-  
+
 }


### PR DESCRIPTION
Running [puppet-lint](http://puppet-lint.com) reported 106 errors and warnings all together. This pull request fixes 103 of them, leaving following 3:

```
puppet/modules/wordpress/manifests/init.pp - WARNING: line has more than 80 characters on line 8
puppet/modules/wordpress/manifests/init.pp - WARNING: line has more than 80 characters on line 13
puppet/modules/wordpress/manifests/init.pp - WARNING: line has more than 80 characters on line 37
```

Additionally [the official style guide](http://docs.puppetlabs.com/guides/style_guide.html) is respected as much as possible.
