### PR TITLE
Set WP_DEBUG to true

### DIFF
--- a/puppet/modules/wordpress/files/wp-config.php
+++ b/puppet/modules/wordpress/files/wp-config.php
@@ -78,7 +78,7 @@ define('WPLANG', '');
  * It is strongly recommended that plugin and theme developers use WP_DEBUG
  * in their development environments.
  */
-define('WP_DEBUG', false);
+define('WP_DEBUG', true);
 
 /* That's all, stop editing! Happy blogging. */
 


### PR DESCRIPTION
As the vagrant VMs are designed for development work it makes more sense to have WP_DEBUG enabled so developers can jump straight into working with less faff. 
