### PR TITLE
Correct issue with static files not refreshing after modification

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@ Rogerio Prado de Jesus
 Joe Cheng
 Matt Ross
 Daryl Lozupone
+Dane Fetterman
 
 People that have offered very valuable assistance with issues and discussion:
 

--- a/files/etc/apache2/sites-available/default
+++ b/files/etc/apache2/sites-available/default
@@ -5,12 +5,8 @@
 	RewriteLogLevel 9
 	RewriteLog ${APACHE_LOG_DIR}/vagrant.rewrite.log
 
-
-# added by dane to correct caching issue where edited images do not refresh
-# http://www.mabishu.com/blog/2013/05/07/solving-caching-issues-with-vagrant-on-vboxsf/
+# correct caching issue where edited images do not refresh http://www.mabishu.com/blog/2013/05/07/solving-caching-issues-with-vagrant-on-vboxsf/
 EnableSendfile off
-
-
 
 	<Directory /vagrant/wordpress>
 	    Options Indexes FollowSymLinks


### PR DESCRIPTION
Adding the "EnableSendfile off" directive to the conf corrects an issue where static files do not refresh after being modified.
