### PR TITLE
Wiki page is not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ You can access phpMyAdmin:
 Feel free to file an issue, create a pull request, or contact me at [my website][chadthompson].
 
 [chadthompson]: http://chadthompson.me
-[ts]: https://github.com/chad-thompson/vagrantpress/wiki/Troubleshooting-tips
+[ts]: https://github.com/vagrantpress/vagrantpress/wiki


### PR DESCRIPTION
Should the page not be https://github.com/vagrantpress/vagrantpress/wiki/Troubleshooting-tips instead of https://github.com/chad-thompson/vagrantpress/wiki/Troubleshooting-tips ?