### PR TITLE
Provide `COMPOSER_HOME` at install time for Composer

### DIFF
--- a/puppet/modules/composer/manifests/init.pp
+++ b/puppet/modules/composer/manifests/init.pp
@@ -8,6 +8,7 @@ class composer::install {
 
   exec { 'install composer':
     command => 'curl -sS https://getcomposer.org/installer | php && sudo mv composer.phar /usr/local/bin/composer',
+    environment => ["COMPOSER_HOME=/usr/local/bin"],
     require => Package['curl'],
   }
 


### PR DESCRIPTION
If the environment does not have a set `HOME` or `COMPOSER_HOME` environment, then composer will throw a Fatal error:

```
==> default: Debug: Exec[install composer](provider=posix): Executing 'curl -sS https://getcomposer.org/installer | php && sudo mv composer.phar /usr/local/bin/composer'
==> default: Debug: Executing 'curl -sS https://getcomposer.org/installer | php && sudo mv composer.phar /usr/local/bin/composer'
==> default: Notice: /Stage[main]/Composer::Install/Exec[install composer]/returns: All settings correct for using Composer
==> default: Notice: /Stage[main]/Composer::Install/Exec[install composer]/returns: PHP Fatal error:  Uncaught exception 'RuntimeException' with message 'The HOME or COMPOSER_HOME environment variable must be set for composer to install correctly' in -:559
==> default: Notice: /Stage[main]/Composer::Install/Exec[install composer]/returns: Stack trace:
==> default: Notice: /Stage[main]/Composer::Install/Exec[install composer]/returns: #0 -(364): getHomeDir()
==> default: Notice: /Stage[main]/Composer::Install/Exec[install composer]/returns: #1 -(111): installComposer(false, false, 'composer.phar', false, false, false)
==> default: Notice: /Stage[main]/Composer::Install/Exec[install composer]/returns: #2 -(13): process(Array)
==> default: Notice: /Stage[main]/Composer::Install/Exec[install composer]/returns: #3 {main}
==> default: Notice: /Stage[main]/Composer::Install/Exec[install composer]/returns:   thrown in - on line 559
==> default: Notice: /Stage[main]/Phpqa::Install/Exec[composer install phpunit]: Dependency Exec[install composer] has failures: true
==> default: Error: curl -sS https://getcomposer.org/installer | php && sudo mv composer.phar /usr/local/bin/composer returned 255 instead of one of [0]
==> default: Error: /Stage[main]/Composer::Install/Exec[install composer]/returns: change from notrun to 0 failed: curl -sS https://getcomposer.org/installer | php && sudo mv composer.phar /usr/local/bin/composer returned 255 instead of one of [0]
==> default: Warning: /Stage[main]/Phpqa::Install/Exec[composer install phpunit]: Skipping because of failed dependencies
[...]
```