### PR TITLE
Fix issue #89 - Allow local .htaccess settings

### DIFF
--- a/files/etc/apache2/sites-available/default.conf
+++ b/files/etc/apache2/sites-available/default.conf
@@ -11,7 +11,7 @@
 
 	<Directory /vagrant/wordpress>
 	    Options Indexes FollowSymLinks
-	    AllowOverride None
+	    AllowOverride FileInfo
 		Require all granted
 	    RewriteEngine On
 	    RewriteBase /


### PR DESCRIPTION
According to the [WP Codex](https://codex.wordpress.org/Using_Permalinks) the minimal Apache directive required for any .htaccess overrides (eg. for pretty permalinks) is AllowOverride FileInfo.