### PR TITLE
Feature: Add WordPress automated tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ latest.tar.gz
 ./wordpress/
 /wordpress/
 /wp-tests/
+/tests/

--- a/puppet/manifests/init.pp
+++ b/puppet/manifests/init.pp
@@ -16,3 +16,4 @@ class { 'wordpress::install': }
 class { 'phpmyadmin::install': }
 class { 'composer::install': }
 class { 'phpqa::install': }
+class { 'tests::install': }

--- a/puppet/modules/tests/files/wp-tests-config.php
+++ b/puppet/modules/tests/files/wp-tests-config.php
@@ -1,0 +1,42 @@
+<?php
+// Source: https://develop.svn.wordpress.org/trunk/wp-tests-config-sample.php
+
+/* Path to the WordPress codebase you'd like to test. Add a forward slash in the end. */
+define( 'ABSPATH', dirname( __FILE__ ) . '/src/' );
+
+// Test with multisite enabled.
+// Alternatively, use the tests/phpunit/multisite.xml configuration file.
+// define( 'WP_TESTS_MULTISITE', true );
+
+// Force known bugs to be run.
+// Tests with an associated Trac ticket that is still open are normally skipped.
+// define( 'WP_TESTS_FORCE_KNOWN_BUGS', true );
+
+// Test with WordPress debug mode (default).
+define( 'WP_DEBUG', true );
+
+// ** MySQL settings ** //
+
+// This configuration file will be used by the copy of WordPress being tested.
+// wordpress/wp-config.php will be ignored.
+
+// WARNING WARNING WARNING!
+// These tests will DROP ALL TABLES in the database with the prefix named below.
+// DO NOT use a production database or one that is shared with something else.
+
+define( 'DB_NAME', 'test' );
+define( 'DB_USER', 'test' );
+define( 'DB_PASSWORD', 'test' );
+define( 'DB_HOST', 'localhost' );
+define( 'DB_CHARSET', 'utf8' );
+define( 'DB_COLLATE', '' );
+
+$table_prefix  = 'wptests_';   // Only numbers, letters, and underscores please!
+
+define( 'WP_TESTS_DOMAIN', 'vagrantpress.dev' );
+define( 'WP_TESTS_EMAIL', 'nobody@vagrantpress.dev' );
+define( 'WP_TESTS_TITLE', 'WordPress automated tests' );
+
+define( 'WP_PHP_BINARY', 'php' );
+
+define( 'WPLANG', '' );

--- a/puppet/modules/tests/manifests/init.pp
+++ b/puppet/modules/tests/manifests/init.pp
@@ -1,0 +1,28 @@
+class tests::install {
+
+  # Create the Wordpress test database
+  exec { 'create-test-database':
+    unless  => '/usr/bin/mysql -u root -pvagrant test',
+    command => '/usr/bin/mysql -u root -pvagrant --execute=\'create database test;\'',
+  }
+
+  exec { 'create-test-user':
+    unless  => '/usr/bin/mysql -u test -ptest test',
+    command => '/usr/bin/mysql -u root -pvagrant --execute="CREATE USER \'test\'@\'localhost\' IDENTIFIED BY \'test\'; GRANT ALL PRIVILEGES ON test.* TO \'test\'@\'localhost\'"',
+  }
+
+  # Download the latest automated test suite
+  # https://make.wordpress.org/core/handbook/testing/automated-testing/phpunit/
+
+  exec { 'download-automated-testing-suite':
+    command => 'svn co --force https://develop.svn.wordpress.org/trunk/ /vagrant/tests',
+    creates => '/vagrant/tests',
+  }
+
+  # Copy a working wp-tests-config.php file for the vagrant setup.
+  file { '/vagrant/tests/wp-tests-config.php':
+    source  => 'puppet:///modules/tests/wp-tests-config.php',
+    require => Exec['download-automated-testing-suite'],
+  }
+
+}


### PR DESCRIPTION
Add new Puppet module for WordPress unit tests documented https://make.wordpress.org/core/handbook/testing/automated-testing/

You can run tests with `cd /vagrant/tests && phpunit`.

It's important to know that the test suite doesn't run on a normal WordPress install. It need it's own install and is only useful if want to test your changes against a vanilla WordPress. You can test plugins, themes, changes to the WP Core.

If you want to contribute to WordPress you'll need the test suite.