### PR TITLE
Bugfix #50: Use WP-CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ I initially created this project to aid in developing child modules for a WordPr
 + Subversion
 + Git
 + Composer
++ WP-CLI
 + ~~PEAR~~
 + Xdebug
 + PHPUnit - **installed via composer*

--- a/puppet/manifests/init.pp
+++ b/puppet/manifests/init.pp
@@ -17,3 +17,4 @@ class { 'phpmyadmin::install': }
 class { 'composer::install': }
 class { 'phpqa::install': }
 class { 'tests::install': }
+class { 'wpcli::install': }

--- a/puppet/modules/wpcli/manifests/init.pp
+++ b/puppet/modules/wpcli/manifests/init.pp
@@ -1,0 +1,7 @@
+class wpcli::install {
+
+  exec { 'download-and-install-wpcli':
+    command => 'curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && chmod +x wp-cli.phar && sudo mv wp-cli.phar /usr/local/bin/wp',
+    creates => '/usr/local/bin/wp',
+  }
+}


### PR DESCRIPTION
WP-CLI installed as wp in /usr/bin/local via Puppet.

This fix #50