### PR TITLE
Feature #112: Increase PHP max upload size

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,6 +14,13 @@ Vagrant.configure("2") do |config|
   config.hostsupdater.aliases = %w{www.vagrantpress.dev}
   config.hostsupdater.remove_on_suspend = true
 
+   config.vm.provision :shell do |shell|
+      shell.inline = "
+        mkdir -p /etc/puppet/modules;
+        puppet module install puppetlabs-stdlib --version 4.11.0 --force;
+      "
+    end
+
   config.vm.provision :puppet do |puppet|
     puppet.manifests_path = "puppet/manifests"
     puppet.module_path = "puppet/modules"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure("2") do |config|
     puppet.manifest_file  = "init.pp"
     puppet.options="--verbose --debug"
   end
-  
+
   # Fix for slow external network connections
   config.vm.provider :virtualbox do |vb|
     vb.memory = 2048

--- a/puppet/modules/php5/manifests/init.pp
+++ b/puppet/modules/php5/manifests/init.pp
@@ -2,18 +2,18 @@
 
 class php5::install {
 
-	package { [
-	  'php5',
-	  'php5-mysql',
-	  'php5-curl',
-	  'php5-gd',
-	  'php5-fpm',
-	  'libapache2-mod-php5',
-	  'php5-dev',
-	  'php5-xdebug'
-	]:
-	ensure => present,
-	}
+  package { [
+    'php5',
+    'php5-mysql',
+    'php5-curl',
+    'php5-gd',
+    'php5-fpm',
+    'libapache2-mod-php5',
+    'php5-dev',
+    'php5-xdebug'
+  ]:
+  ensure => present,
+  }
 
   file_line { 'php_max_upload_remove_default':
     path    => '/etc/php5/apache2/php.ini',

--- a/puppet/modules/php5/manifests/init.pp
+++ b/puppet/modules/php5/manifests/init.pp
@@ -14,4 +14,18 @@ class php5::install {
 	]:
 	ensure => present,
 	}
+
+  file_line { 'php_max_upload_remove_default':
+    path    => '/etc/php5/apache2/php.ini',
+    line    => 'upload_max_filesize = 2M',
+    ensure  => 'absent',
+    require => Package['php5'],
+  }
+
+  file_line { 'php_max_upload_add_custom':
+    path    => '/etc/php5/apache2/php.ini',
+    line    => 'upload_max_filesize = 200M',
+    after   => '; http://php.net/upload-max-filesize',
+    require => Package['php5'],
+  }
 }


### PR DESCRIPTION
Vagrant now install Puppet standard lib which allow changes in specific files and many other features.

Puppet change default max_upload_size to 200M in apache only. Doesn't affect the command line and other php instances.

This close #112