### PR TITLE
Migrate from MySQL to MariaDB.

### DIFF
--- a/puppet/manifests/init.pp
+++ b/puppet/manifests/init.pp
@@ -11,7 +11,7 @@ class { 'git::install': }
 class { 'subversion::install': }
 class { 'apache2::install': }
 class { 'php5::install': }
-class { 'mysql::install': }
+class { 'mariadb::install': }
 class { 'wordpress::install': }
 class { 'phpmyadmin::install': }
 class { 'composer::install': }

--- a/puppet/modules/mariadb/manifests/init.pp
+++ b/puppet/modules/mariadb/manifests/init.pp
@@ -1,20 +1,20 @@
-#Install MySQL
+#Install MariaDB
 
-class mysql::install {
+class mariadb::install {
 
   $password = 'vagrant'
 
   package { [
-      'mysql-client',
-      'mysql-server',
+      'mariadb-client',
+      'mariadb-server',
     ]:
     ensure => installed,
   }
 
   exec { 'Set MySQL server\'s root password':
     subscribe   => [
-      Package['mysql-server'],
-      Package['mysql-client'],
+      Package['mariadb-server'],
+      Package['mariadb-client'],
     ],
     refreshonly => true,
     unless      => "mysqladmin -uroot -p${password} status",

--- a/puppet/modules/tests/files/wp-tests-config.php
+++ b/puppet/modules/tests/files/wp-tests-config.php
@@ -15,7 +15,7 @@ define( 'ABSPATH', dirname( __FILE__ ) . '/src/' );
 // Test with WordPress debug mode (default).
 define( 'WP_DEBUG', true );
 
-// ** MySQL settings ** //
+// ** MariaDB settings ** //
 
 // This configuration file will be used by the copy of WordPress being tested.
 // wordpress/wp-config.php will be ignored.

--- a/puppet/modules/wordpress/files/wp-config.php
+++ b/puppet/modules/wordpress/files/wp-config.php
@@ -2,10 +2,10 @@
 /**
  * The base configurations of the WordPress.
  *
- * This file has the following configurations: MySQL settings, Table Prefix,
+ * This file has the following configurations: MariaDB settings, Table Prefix,
  * Secret Keys, WordPress Language, and ABSPATH. You can find more information
  * by visiting {@link http://codex.wordpress.org/Editing_wp-config.php Editing
- * wp-config.php} Codex page. You can get the MySQL settings from your web host.
+ * wp-config.php} Codex page. You can get the MariaDB settings from your web host.
  *
  * This file is used by the wp-config.php creation script during the
  * installation. You don't have to use the web site, you can just copy this file
@@ -14,17 +14,17 @@
  * @package WordPress
  */
 
-// ** MySQL settings - You can get this info from your web host ** //
+// ** MariaDB settings - You can get this info from your web host ** //
 /** The name of the database for WordPress */
 define('DB_NAME', 'wordpress');
 
-/** MySQL database username */
+/** MariaDB database username */
 define('DB_USER', 'wordpress');
 
-/** MySQL database password */
+/** MariaDB database password */
 define('DB_PASSWORD', 'wordpress');
 
-/** MySQL hostname */
+/** MariaDB hostname */
 define('DB_HOST', 'localhost');
 
 /** Database Charset to use in creating database tables. */


### PR DESCRIPTION
Just in case you didn't know, MySQL is owned by Oracle and is kinda
dead. MySQL creator left the project and started MariaDB and it rocks.

http://www.computerworld.com.au/article/457551/dead_database_walking_mysql_creator_why_future_belongs_mariadb/

WordPress PHPunit with MySQL: Time: 2.12 minutes
WordPress PHPunit with Maria: Time: 1.88 minutes