### PR TITLE
Enable PHP7 on Ubuntu 14.04

### DIFF
--- a/puppet/manifests/init.pp
+++ b/puppet/manifests/init.pp
@@ -11,6 +11,7 @@ class { 'git::install': }
 class { 'subversion::install': }
 class { 'apache2::install': }
 class { 'php5::install': }
+class { 'php7::install': }
 class { 'mariadb::install': }
 class { 'wordpress::install': }
 class { 'phpmyadmin::install': }

--- a/puppet/modules/php7/manifests/init.pp
+++ b/puppet/modules/php7/manifests/init.pp
@@ -1,0 +1,10 @@
+class php7::install {
+
+  exec { "install_php7":
+    command => "add-apt-repository ppa:ondrej/php -y && apt-get update -y && apt-get install php7.0 php7.0-mysql php7.0-curl php7.0-gd php7.0-fpm php7.0-dev php7.0-xdebug libapache2-mod-php7.0 php7.0-xdebug php7.0-mbstring -y && a2enmod proxy_fcgi setenvif && a2enconf php7.0-fpm && service apache2 restart",
+    user => "root",
+    require => Package['php5'],
+    notify => Service['apache2'],
+  }
+
+}


### PR DESCRIPTION
PHP7 come with Ubuntu 16.04 but since we can't run it yet we can use
this hack.

I used this guide as a help to install PHP7.
https://www.digitalocean.com/community/tutorials/how-to-upgrade-to-php-7-on-ubuntu-14-04

All WP unit tests succeed and suite run in 60sec instead of 120sec.
50%  performance gain, and we can code with new PHP7 features :)

Puppet script is really dirty but works.
We'll be able to ditch it once we get native Ubuntu 16.04.