### PR TITLE
Made PHP7 puppet code readable by humans

### DIFF
--- a/puppet/manifests/init.pp
+++ b/puppet/manifests/init.pp
@@ -10,7 +10,7 @@ Exec { path => [ "/bin/", "/sbin/" , "/usr/bin/", "/usr/sbin/", "/usr/local/bin"
 class { 'git::install': }
 class { 'subversion::install': }
 class { 'apache2::install': }
-class { 'php5::install': }
+#class { 'php5::install': }
 class { 'php7::install': }
 class { 'mariadb::install': }
 class { 'wordpress::install': }

--- a/puppet/modules/php7/manifests/init.pp
+++ b/puppet/modules/php7/manifests/init.pp
@@ -1,9 +1,8 @@
 class php7::install {
 
   exec { "install_php7":
-    command => "add-apt-repository ppa:ondrej/php -y && apt-get update -y && apt-get install php7.0 php7.0-mysql php7.0-curl php7.0-gd php7.0-fpm php7.0-dev php7.0-xdebug libapache2-mod-php7.0 php7.0-xdebug php7.0-mbstring -y && a2enmod proxy_fcgi setenvif && a2enconf php7.0-fpm && a2dismod php5 && a2enmod php7.0 && service apache2 restart",
+    command => "add-apt-repository ppa:ondrej/php -y && apt-get update -y && apt-get install php7.0 php7.0-mysql php7.0-curl php7.0-gd php7.0-fpm php7.0-dev php7.0-xdebug libapache2-mod-php7.0 php7.0-xdebug php7.0-mbstring -y && a2enmod proxy_fcgi setenvif && a2enconf php7.0-fpm && a2enmod php7.0 && service apache2 restart",
     user => "root",
-    require => Package['php5'],
     notify => Service['apache2'],
   }
 

--- a/puppet/modules/php7/manifests/init.pp
+++ b/puppet/modules/php7/manifests/init.pp
@@ -1,7 +1,23 @@
 class php7::install {
 
   exec { "install_php7":
-    command => "add-apt-repository ppa:ondrej/php -y && apt-get update -y && apt-get install php7.0 php7.0-mysql php7.0-curl php7.0-gd php7.0-fpm php7.0-dev php7.0-xdebug libapache2-mod-php7.0 php7.0-xdebug php7.0-mbstring -y && a2enmod proxy_fcgi setenvif && a2enconf php7.0-fpm && a2enmod php7.0 && service apache2 restart",
+    command =>
+     "add-apt-repository ppa:ondrej/php -y\
+      && apt-get update -y\
+      && apt-get install -y\
+        php7.0\
+        php7.0-mysql\
+        php7.0-curl\
+        php7.0-gd\
+        php7.0-fpm\
+        php7.0-dev\
+        php7.0-xdebug\
+        php7.0-mbstring\
+        libapache2-mod-php7.0\
+      && a2dismod php5\
+      && a2enmod proxy_fcgi setenvif\
+      && a2enconf php7.0-fpm\
+      && a2enmod php7.0",
     user => "root",
     notify => Service['apache2'],
   }


### PR DESCRIPTION
Tried for the 2nd time to use legit puppet code like (apt::ppa) to
install PHP7 ppa but failed.

So for now, we'll make the code readable by humans.

Also removed a duplicate package and removed apache2 manual restart
since puppet restart a2 via `notify` anyway.