### PR TITLE
Add support for vagrant-hostmanager plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ latest.tar.gz
 /wordpress/
 /wp-tests/
 /tests/
+.idea/

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ I initially created this project to aid in developing child modules for a WordPr
 
 + [Vagrant](http://www.vagrantup.com/downloads.html)
 + [Virtualbox](https://www.virtualbox.org/wiki/Downloads)
-+ [Vagrant Hostsupdater](https://github.com/cogitatio/vagrant-hostsupdater)
++ [Vagrant Hostsupdater](https://github.com/cogitatio/vagrant-hostsupdater) or [Vagrant Hostmanager](https://github.com/devopsgroup-io/vagrant-hostmanager) plugin
 
 ## Getting Started
 


### PR DESCRIPTION
I use vagrant-hostmanager for several other projects so rather than juggle host manager plugins I added support for vagrant-hostmanager to vagrantpress. I also dropped in a fix for that annoying "stdin: is not a tty" error message from the shell provisioner. 

Let me know if there's anything else I need to do to make this merge-worthy. 